### PR TITLE
Ensure valid DateTime format for DB

### DIFF
--- a/src/datastudio/migrations/m211101_000008_migrate_reports_tables.php
+++ b/src/datastudio/migrations/m211101_000008_migrate_reports_tables.php
@@ -7,6 +7,7 @@ use craft\db\Migration;
 use craft\db\Query;
 use craft\db\Table;
 use craft\helpers\DateTimeHelper;
+use craft\helpers\Db;
 use craft\helpers\StringHelper;
 
 class m211101_000008_migrate_reports_tables extends Migration
@@ -128,12 +129,14 @@ class m211101_000008_migrate_reports_tables extends Migration
                     unset($rows[$key]);
                 }
 
+                $now = Db::prepareDateForDb(DateTimeHelper::now());
+
                 // Create a row in the content table for each element to support custom fields
                 $this->insert(Table::CONTENT, [
                     'elementId' => $row['id'],
                     'siteId' => $row['siteId'],
-                    'dateCreated' => DateTimeHelper::toIso8601(DateTimeHelper::now()),
-                    'dateUpdated' => DateTimeHelper::toIso8601(DateTimeHelper::now()),
+                    'dateCreated' => $now,
+                    'dateUpdated' => $now,
                     'uid' => StringHelper::UUID(),
                 ]);
 


### PR DESCRIPTION
This PR addresses issue:
https://github.com/barrelstrength/craft-sprout-data-studio/issues/2

This pull request changes:

1. Strips the timezone of `DateTimeHelper::now()` to prevent a formatting error when inserting DateTime values into DB

Best,
Niklas

- [x] I have linked to the Sprout Plugin Github Issue this PR resolves
- [x] I have described what this PR adds/removes/changes

<!-------------------------------------------------------------
Report issues in the repository for the plugin where the issue was encountered. If no issue exists, first create an issue describing the problem in the appropriate plugin repository and link to the issue above.
e.g. https://github.com/barrelstrength/craft-sprout-plugin-name/123
--------------------------------------------------------------->
