### PR TITLE
Include class name of dataset when checking for permissions

### DIFF
--- a/src/datastudio/controllers/DataSetController.php
+++ b/src/datastudio/controllers/DataSetController.php
@@ -110,7 +110,7 @@ class DataSetController extends Controller
             'dataSource' => $dataSource,
             'labels' => $labels,
             'values' => $values,
-            'canEditDataSet' => $currentUser->can(DataStudioModule::p('editDataSet')),
+            'canEditDataSet' => $currentUser->can(DataStudioModule::p('editDataSet:' . $dataSource::class)),
             'disabledExportButtonHtml' => Template::raw($disabledExportButtonHtml),
         ]);
     }


### PR DESCRIPTION
This PR addresses issue:
https://github.com/barrelstrength/sprout-data-studio/issues/8

This pull request changes:
- When checking if a user has permission to edit a data set, include the respective class name

Best,
Niklas

- [X] I have linked to the Sprout Plugin Github Issue this PR resolves
- [X] I have described what this PR adds/removes/changes

<!-------------------------------------------------------------
Report issues in the repository for the plugin where the issue was encountered. If no issue exists, first create an issue describing the problem in the appropriate plugin repository and link to the issue above.
e.g. https://github.com/barrelstrength/craft-sprout-plugin-name/123
--------------------------------------------------------------->
