### PR TITLE
Add missing aliases for tables

### DIFF
--- a/src/datastudio/migrations/m211101_000008_migrate_reports_tables.php
+++ b/src/datastudio/migrations/m211101_000008_migrate_reports_tables.php
@@ -109,9 +109,9 @@ class m211101_000008_migrate_reports_tables extends Migration
 
             $rows = (new Query())
                 ->select($oldTableCols)
-                ->from([self::OLD_REPORTS_TABLE])
+                ->from(['sproutreports_reports' => self::OLD_REPORTS_TABLE])
                 ->innerJoin(
-                    Table::ELEMENTS_SITES,
+                    ['elements_sites' => Table::ELEMENTS_SITES],
                     '[[sproutreports_reports.id]] = [[elements_sites.elementId]]'
                 )
                 ->all();


### PR DESCRIPTION
This PR addresses issue:
[Migration error from 3.x from Sprout Reports, missing table aliases](https://github.com/barrelstrength/sprout/issues/252)

This pull request changes:
1. Add missing aliases for tables during migration for `m211101_000008_migrate_reports_tables.php`

Signature, _(add an `[x]` within each checkbox to confirm)_

- [X] I have linked to the Sprout Plugin Github Issue this PR resolves
- [X] I have described what this PR adds/removes/changes

**Checked locally, after that fix, the migration is correctly applied & plugin installed**

<!-------------------------------------------------------------
Report issues in the repository for the plugin where the issue was encountered. If no issue exists, first create an issue describing the problem in the appropriate plugin repository and link to the issue above.
e.g. https://github.com/barrelstrength/craft-sprout-plugin-name/123
--------------------------------------------------------------->
