### PR TITLE
Prevent PHP error in ConditionHelper when Commerce is installed

### DIFF
--- a/src/core/helpers/ConditionHelper.php
+++ b/src/core/helpers/ConditionHelper.php
@@ -10,7 +10,7 @@ class ConditionHelper
 {
     public static function registerConditionRuleTypes(RegisterConditionRulesEvent $event): void
     {
-        $elementType = $event->sender?->elementType;
+        $elementType = $event->sender?->elementType ?? null;
 
         if ($elementType === null) {
             return;


### PR DESCRIPTION
This PR addresses issue: https://github.com/barrelstrength/sprout/issues/329

This pull request adds/removes/changes:

1. Prevents fatal error when Sprout Data Studio and Craft Commerce are installed at the same time.

Signature, _(add an `[x]` within each checkbox to confirm)_

- [X] I have linked to the Sprout Plugin Github Issue this PR resolves
- [X] I have described what this PR adds/removes/changes