### PR TITLE
Fix `processHeaderRow` logic to handle empty rows and ensure proper processing

### DIFF
--- a/src/core/helpers/ConditionHelper.php
+++ b/src/core/helpers/ConditionHelper.php
@@ -10,7 +10,7 @@ class ConditionHelper
 {
     public static function registerConditionRuleTypes(RegisterConditionRulesEvent $event): void
     {
-        $elementType = $event->sender?->elementType;
+        $elementType = $event->sender?->elementType ?? null;
 
         if ($elementType === null) {
             return;

--- a/src/datastudio/components/datasources/CustomTwigTemplateQueryDataSource.php
+++ b/src/datastudio/components/datasources/CustomTwigTemplateQueryDataSource.php
@@ -176,23 +176,21 @@ class CustomTwigTemplateQueryDataSource extends DataSource
         // If we don't have default labels, we will use the first row as for our column headers
         // We do so by making the first row the keys of the second row
         if (empty($labels) && is_countable($rows) && count($rows) === 0) {
-            return;
-        }
+            $headerRow = [];
 
-        $headerRow = [];
+            /** @var array $firstRowColumns */
+            $firstRowColumns = array_shift($rows);
 
-        /** @var array $firstRowColumns */
-        $firstRowColumns = array_shift($rows);
+            if (is_countable($firstRowColumns) && count($firstRowColumns) > 0) {
+                $secondRow = array_shift($rows);
 
-        if (is_countable($firstRowColumns) && count($firstRowColumns) > 0) {
-            $secondRow = array_shift($rows);
-
-            foreach ($firstRowColumns as $key => $column) {
-                $headerRow[$column] = $secondRow[$key];
+                foreach ($firstRowColumns as $key => $column) {
+                    $headerRow[$column] = $secondRow[$key];
+                }
             }
-        }
 
-        array_unshift($rows, $headerRow);
+            array_unshift($rows, $headerRow);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR addresses issue: https://github.com/barrelstrength/sprout/issues/336

This pull request adds/removes/changes:

1. Fix early return that prevented the intended header row processing logic from executing.

Signature, _(add an `[x]` within each checkbox to confirm)_

- [x] I have linked to the Sprout Plugin Github Issue this PR resolves
- [x] I have described what this PR adds/removes/changes
