### PR TITLE
Don't attempt to load site-specific settings unless running Pro edition

### DIFF
--- a/src/redirects/RedirectsSettings.php
+++ b/src/redirects/RedirectsSettings.php
@@ -121,6 +121,10 @@ class RedirectsSettings extends BaseConfig
             return $this->_siteExcludedUrlPatterns;
         }
 
+        if (!RedirectsModule::getInstance()->isPro()) {
+            return null;
+        }
+
         $settings = SettingsRecord::find()
             ->select('settings')
             ->where([


### PR DESCRIPTION
This PR addresses issue:
https://github.com/barrelstrength/sprout/issues/350

This pull request adds a check to whether the Edition is Pro or not. If not, it skips the site-specific URL exclusion patterns check. 

Signature, _(add an `[x]` within each checkbox to confirm)_

- [x] I have linked to the Sprout Plugin Github Issue this PR resolves
- [x] I have described what this PR adds/removes/changes

