### PR TITLE
Update build of query string for Redirect

### DIFF
--- a/src/redirects/redirects/Redirects.php
+++ b/src/redirects/redirects/Redirects.php
@@ -92,7 +92,8 @@ class Redirects extends Component
         if ($settings->queryStringStrategy === QueryStringStrategy::REMOVE_QUERY_STRINGS) {
             $queryString = '';
         } elseif ($settings->queryStringStrategy === QueryStringStrategy::APPEND_QUERY_STRINGS) {
-            $queryString = '?' . $request->getQueryStringWithoutPath();
+            $requestQueryString = $request->getQueryStringWithoutPath();
+            $queryString = $requestQueryString !== '' ? '?' . $requestQueryString : '';
         } else {
             return;
         }


### PR DESCRIPTION
When building the new URL for Redirects with the APPEND_QUERY_STRINGS Strategy, add a check for empty query string in request to avoid unnecessary trailing `?` in target URL

fixes #353

This PR addresses issue: #353 

This pull request changes:

1. `BarrelStrength\Sprout\redirects\redirects\Redirects::processRedirectsForCurrentRequest`
Add a check for empty query string when instantiating `$queryString`



Signature, _(add an `[x]` within each checkbox to confirm)_

- [x] I have linked to the Sprout Plugin Github Issue this PR resolves
- [x] I have described what this PR adds/removes/changes

<!-------------------------------------------------------------
Report issues in the repository for the plugin where the issue was encountered. If no issue exists, first create an issue describing the problem in the appropriate plugin repository and link to the issue above.
e.g. https://github.com/barrelstrength/craft-sprout-plugin-name/123
--------------------------------------------------------------->
