### PR TITLE
Update RedirectHelper

### DIFF
--- a/src/redirects/redirects/RedirectHelper.php
+++ b/src/redirects/redirects/RedirectHelper.php
@@ -143,7 +143,7 @@ class RedirectHelper
                 }
             } elseif ($baseSiteUrl . $redirect['oldUrl'] === $absoluteUrl) {
                 // Update null value to return home page
-                $redirect['newUrl'] ??= '/';
+                $redirect['newUrl'] ??= '';
 
                 return new RedirectElement($redirect);
             }


### PR DESCRIPTION
Update RedirectElement newUrl initialization, set empty string for homepage redirections to avoid adding an extra slash to the URL.

This PR addresses issue: #355 

This pull request changes:

1. BarrelStrength\Sprout\redirects\redirects\RedirectHelper::findUrl()`


Signature, _(add an `[x]` within each checkbox to confirm)_

- [x] I have linked to the Sprout Plugin Github Issue this PR resolves
- [x] I have described what this PR adds/removes/changes

<!-------------------------------------------------------------
Report issues in the repository for the plugin where the issue was encountered. If no issue exists, first create an issue describing the problem in the appropriate plugin repository and link to the issue above.
e.g. https://github.com/barrelstrength/craft-sprout-plugin-name/123
--------------------------------------------------------------->
